### PR TITLE
feat!: Upgrade AWS provider and min required Terraform version to `6.0` and `1.5.7` respectively

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,14 +118,14 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.82 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.82 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
@@ -174,6 +174,7 @@ No modules.
 | <a name="input_parameter_group_tags"></a> [parameter\_group\_tags](#input\_parameter\_group\_tags) | Additional tags for the parameter group created | `map(string)` | `{}` | no |
 | <a name="input_parameter_group_use_name_prefix"></a> [parameter\_group\_use\_name\_prefix](#input\_parameter\_group\_use\_name\_prefix) | Determines whether `parameter_group_name` is used as a prefix | `bool` | `false` | no |
 | <a name="input_port"></a> [port](#input\_port) | The port number on which each of the nodes accepts connections. Defaults to `6379` | `number` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | Region where this resource will be managed. Defaults to the Region set in the provider configuration | `string` | `null` | no |
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | Set of VPC Security Group ID-s to associate with this cluster | `list(string)` | `null` | no |
 | <a name="input_snapshot_arns"></a> [snapshot\_arns](#input\_snapshot\_arns) | List of ARN-s that uniquely identify RDB snapshot files stored in S3. The snapshot files will be used to populate the new cluster | `list(string)` | `null` | no |
 | <a name="input_snapshot_name"></a> [snapshot\_name](#input\_snapshot\_name) | The name of a snapshot from which to restore data into the new cluster | `string` | `null` | no |
@@ -188,7 +189,7 @@ No modules.
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to use on all resources | `map(string)` | `{}` | no |
 | <a name="input_tls_enabled"></a> [tls\_enabled](#input\_tls\_enabled) | A flag to enable in-transit encryption on the cluster. When set to `false`, the `acl_name` must be `open-access`. Defaults to `true` | `bool` | `null` | no |
 | <a name="input_use_name_prefix"></a> [use\_name\_prefix](#input\_use\_name\_prefix) | Determines whether `name` is used as a prefix for the cluster | `bool` | `false` | no |
-| <a name="input_users"></a> [users](#input\_users) | A map of user definitions (maps) to be created | `any` | `{}` | no |
+| <a name="input_users"></a> [users](#input\_users) | A map of user definitions (maps) to be created | <pre>map(object({<br/>    user_name     = string<br/>    access_string = string<br/>    type          = optional(string, "password")<br/>    passwords     = optional(list(string))<br/>    tags          = optional(map(string), {})<br/>  }))</pre> | `{}` | no |
 
 ## Outputs
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -25,15 +25,15 @@ Note that this example may create resources which will incur monetary charges on
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.82 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.82 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Modules
@@ -43,7 +43,7 @@ Note that this example may create resources which will incur monetary charges on
 | <a name="module_memory_db"></a> [memory\_db](#module\_memory\_db) | ../.. | n/a |
 | <a name="module_memory_db_disabled"></a> [memory\_db\_disabled](#module\_memory\_db\_disabled) | ../.. | n/a |
 | <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 6.0 |
 
 ## Resources
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -95,7 +95,7 @@ module "memory_db" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 5.0"
+  version = "~> 6.0"
 
   name = local.name
   cidr = "10.99.0.0/18"

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.5.7"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.82"
+      version = ">= 6.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/valkey/README.md
+++ b/examples/valkey/README.md
@@ -25,15 +25,15 @@ Note that this example may create resources which will incur monetary charges on
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.82 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.82 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Modules
@@ -43,7 +43,7 @@ Note that this example may create resources which will incur monetary charges on
 | <a name="module_memory_db"></a> [memory\_db](#module\_memory\_db) | ../.. | n/a |
 | <a name="module_memory_db_disabled"></a> [memory\_db\_disabled](#module\_memory\_db\_disabled) | ../.. | n/a |
 | <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 6.0 |
 
 ## Resources
 

--- a/examples/valkey/main.tf
+++ b/examples/valkey/main.tf
@@ -96,7 +96,7 @@ module "memory_db" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 5.0"
+  version = "~> 6.0"
 
   name = local.name
   cidr = "10.98.0.0/18"

--- a/examples/valkey/versions.tf
+++ b/examples/valkey/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.5.7"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.82"
+      version = ">= 6.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/main.tf
+++ b/main.tf
@@ -45,6 +45,7 @@ resource "aws_memorydb_cluster" "this" {
   snapshot_retention_limit = var.snapshot_retention_limit
   snapshot_window          = var.snapshot_window
   final_snapshot_name      = var.final_snapshot_name
+  region                   = var.region
 
   tags = var.tags
 }
@@ -58,13 +59,14 @@ resource "aws_memorydb_user" "this" {
 
   user_name     = each.value.user_name
   access_string = each.value.access_string
+  region        = var.region
 
   authentication_mode {
-    type      = try(each.value.type, "password")
-    passwords = try(each.value.passwords, null)
+    type      = each.value.type
+    passwords = each.value.passwords
   }
 
-  tags = merge(var.tags, lookup(each.value, "tags", {}))
+  tags = merge(var.tags, each.value.tags)
 }
 
 ################################################################################
@@ -78,6 +80,7 @@ resource "aws_memorydb_acl" "this" {
   name_prefix = var.acl_use_name_prefix ? "${local.create_acl_name}-" : null
 
   user_names = distinct(concat([for u in aws_memorydb_user.this : u.id], var.acl_user_names))
+  region     = var.region
 
   lifecycle {
     create_before_destroy = true
@@ -97,6 +100,7 @@ resource "aws_memorydb_parameter_group" "this" {
   name_prefix = var.parameter_group_use_name_prefix ? "${local.create_parameter_group_name}-" : null
   description = var.parameter_group_description
   family      = var.parameter_group_family
+  region      = var.region
 
   dynamic "parameter" {
     for_each = var.parameter_group_parameters
@@ -124,6 +128,7 @@ resource "aws_memorydb_subnet_group" "this" {
   name_prefix = var.subnet_group_use_name_prefix ? "${local.create_subnet_group_name}-" : null
   description = var.subnet_group_description
   subnet_ids  = var.subnet_ids
+  region      = var.region
 
   lifecycle {
     create_before_destroy = true

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "create" {
   default     = true
 }
 
+variable "region" {
+  description = "Region where this resource will be managed. Defaults to the Region set in the provider configuration"
+  type        = string
+  default     = null
+}
+
 variable "tags" {
   description = "A map of tags to use on all resources"
   type        = map(string)
@@ -158,8 +164,15 @@ variable "create_users" {
 
 variable "users" {
   description = "A map of user definitions (maps) to be created"
-  type        = any
-  default     = {}
+  type = map(object({
+    user_name     = string
+    access_string = string
+    type          = optional(string, "password")
+    passwords     = optional(list(string))
+    tags          = optional(map(string), {})
+  }))
+  default  = {}
+  nullable = false
 }
 
 ################################################################################

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.5.7"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.82"
+      version = ">= 6.0"
     }
   }
 }


### PR DESCRIPTION
## Description
AWS MSV 6 and Terraform MSV 1.5.7.
Support region argument for all resources. 

## Motivation and Context
- https://github.com/terraform-aws-modules/terraform-aws-memory-db/issues/15

## Breaking Changes
Yes, major versions for AWS provider and Terraform. 

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
